### PR TITLE
Add 2D sugar for scale

### DIFF
--- a/lib/twodunpacker.js
+++ b/lib/twodunpacker.js
@@ -113,6 +113,7 @@ propertyMapping = {
   center: ['center-x', 'center-y'],
   'intrinsic-size': ['intrinsic-width', 'intrinsic-height'],
   position: ['x', 'y'],
+  scale: ['scale-x', 'scale-y'],
   size: ['width', 'height'],
   'top-left': ['left', 'top'],
   'top-right': ['right', 'top']

--- a/src/twodunpacker.coffee
+++ b/src/twodunpacker.coffee
@@ -69,6 +69,7 @@ propertyMapping =
   center          : ['center-x', 'center-y']
   'intrinsic-size': ['intrinsic-width', 'intrinsic-height']
   position        : ['x', 'y']
+  scale           : ['scale-x', 'scale-y']
   size            : ['width', 'height']
   'top-left'      : ['left', 'top']
   'top-right'     : ['right', 'top']


### PR DESCRIPTION
I believe `scale-x` and `scale-y` will be introduced in v2.1 of the engine.

This pull request allows:
```
scale: = 1 - number / 10;
```

as convenience for:
```
scale-x: = 1 - number / 10;
scale-y: = 1 - number / 10;
```